### PR TITLE
feat: add polished error handling pages (error, not-found, global-error)

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useEffect } from "react"
+import Link from "next/link"
+import { AlertTriangle, Home, RotateCcw } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+
+interface ErrorProps {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function Error({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-8 text-center">
+      <div className="flex flex-col items-center gap-5">
+        <div className="rounded-full border border-destructive/20 bg-destructive/10 p-5">
+          <AlertTriangle
+            className="h-10 w-10 text-destructive"
+            aria-hidden="true"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight">
+            Something went wrong
+          </h1>
+          <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+            An unexpected error occurred. You can try to recover below, or head
+            back home.
+          </p>
+        </div>
+
+        {error.digest && (
+          <>
+            <Separator className="max-w-xs" />
+            <p className="font-mono text-xs text-muted-foreground/60">
+              Digest: <span className="select-all">{error.digest}</span>
+            </p>
+          </>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Button onClick={reset}>
+          <RotateCcw className="mr-2 h-4 w-4" />
+          Try again
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/">
+            <Home className="mr-2 h-4 w-4" />
+            Go home
+          </Link>
+        </Button>
+      </div>
+    </main>
+  )
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { useEffect } from "react"
+import { AlertOctagon, RotateCcw } from "lucide-react"
+
+interface GlobalErrorProps {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+/**
+ * global-error.tsx catches errors thrown inside the root layout.
+ * Because it replaces the root layout entirely, it MUST render
+ * its own <html> and <body> tags — Tailwind and shadcn/ui are
+ * unavailable here, so styles are inlined.
+ */
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+          backgroundColor: "#ffffff",
+          color: "#09090b",
+        }}
+      >
+        <main
+          style={{
+            display: "flex",
+            minHeight: "100vh",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "2rem",
+            padding: "2rem",
+            textAlign: "center",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "1.25rem",
+            }}
+          >
+            <div
+              style={{
+                borderRadius: "9999px",
+                border: "1px solid #fecaca",
+                backgroundColor: "#fef2f2",
+                padding: "1.25rem",
+              }}
+            >
+              <AlertOctagon
+                aria-hidden="true"
+                style={{ width: "2.5rem", height: "2.5rem", color: "#dc2626" }}
+              />
+            </div>
+
+            <div>
+              <p
+                style={{
+                  fontSize: "0.75rem",
+                  fontWeight: 500,
+                  letterSpacing: "0.15em",
+                  textTransform: "uppercase",
+                  color: "#71717a",
+                  marginBottom: "0.5rem",
+                }}
+              >
+                Critical Error
+              </p>
+              <h1
+                style={{
+                  fontSize: "1.875rem",
+                  fontWeight: 700,
+                  letterSpacing: "-0.025em",
+                  margin: "0 0 0.5rem",
+                }}
+              >
+                Application failed to load
+              </h1>
+              <p
+                style={{
+                  fontSize: "0.875rem",
+                  color: "#71717a",
+                  maxWidth: "28rem",
+                  margin: "0 auto",
+                }}
+              >
+                A critical error occurred in the application root. Please try
+                again — if the problem persists, contact support.
+              </p>
+
+              {error.digest && (
+                <p
+                  style={{
+                    marginTop: "0.75rem",
+                    fontFamily: "ui-monospace, monospace",
+                    fontSize: "0.7rem",
+                    color: "#a1a1aa",
+                  }}
+                >
+                  Digest:{" "}
+                  <span style={{ userSelect: "all" }}>{error.digest}</span>
+                </p>
+              )}
+            </div>
+          </div>
+
+          <button
+            onClick={reset}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.5rem",
+              padding: "0.5rem 1.25rem",
+              borderRadius: "0.375rem",
+              backgroundColor: "#18181b",
+              color: "#fafafa",
+              border: "none",
+              cursor: "pointer",
+              fontSize: "0.875rem",
+              fontWeight: 500,
+              transition: "background-color 0.15s",
+            }}
+            onMouseOver={(e) =>
+              ((e.currentTarget as HTMLButtonElement).style.backgroundColor =
+                "#27272a")
+            }
+            onMouseOut={(e) =>
+              ((e.currentTarget as HTMLButtonElement).style.backgroundColor =
+                "#18181b")
+            }
+          >
+            <RotateCcw style={{ width: "1rem", height: "1rem" }} />
+            Try again
+          </button>
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link"
+import { FileSearch, Home } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-8 text-center">
+      <div className="flex flex-col items-center gap-5">
+        <div className="rounded-full border bg-muted/50 p-5">
+          <FileSearch
+            className="h-10 w-10 text-muted-foreground"
+            aria-hidden="true"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">
+            404
+          </p>
+          <h1 className="text-3xl font-bold tracking-tight">Page not found</h1>
+          <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+            The page you&apos;re looking for doesn&apos;t exist or has been
+            moved.
+          </p>
+        </div>
+      </div>
+
+      <Button asChild>
+        <Link href="/">
+          <Home className="mr-2 h-4 w-4" />
+          Back to home
+        </Link>
+      </Button>
+    </main>
+  )
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }


### PR DESCRIPTION
# feat: add polished error handling pages
 **What this PR adds**
Three new files under `src/app/` to cover all Next.js 14 app router error surface areas:

| File | Handles |
|------|---------|
| `error.tsx` | Runtime errors within a route segment |
| `not-found.tsx` | 404s from `notFound()` or unknown routes |
| `global-error.tsx` | Errors thrown inside the root `layout.tsx` |

 **Why it belongs in this template**

The template is described as "ready to use — jump right into development." Error boundaries are a production requirement, not an afterthought — but Next.js does not scaffold them by default. Adding them here means every project started from this template has a safe, consistent error UX from day one.

 **Design decisions**
- **`error.tsx` and `not-found.tsx`** use `shadcn/ui` components (`Button`, `Separator`) and Tailwind classes so they inherit any theme customizations automatically.
- **`global-error.tsx`** uses inline styles intentionally — because it replaces the root layout entirely, Tailwind and the global CSS file are unavailable at that point.
- The `error.digest` value is surfaced (when present) to aid debugging in production without exposing a raw stack trace.
- Icons are sourced from `lucide-react`, already a dependency of `shadcn/ui`.

**Checklist**

- No new dependencies added
-TypeScript strict-compatible
- Follows existing file structure (`src/app/`)
- Consistent with shadcn/ui design language
- `global-error.tsx` correctly includes `<html>` and `<body>` per Next.js requirements
